### PR TITLE
ci: Initial support for building a dev BOSH release

### DIFF
--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,0 +1,5 @@
+credentials.yml
+credentials-*.yml
+*.tfstate
+*.tfstate.backup
+

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,68 @@
+# Deploy CI Infrastructure
+
+1. Export your project ID, a prefix, and the pipeline (develop or prod):
+
+  ```
+  projectid=<REPLACE_WITH_YOUR_PROJECT_ID>
+  prefix=gcp-tools-release
+  pipeline=develop
+  ```
+
+1. Create a service account and key:
+
+  ```
+  gcloud iam service-accounts create ${pipeline}-${prefix}
+  gcloud iam service-accounts keys create /tmp/${pipeline}-${prefix}.key.json \
+      --iam-account ${pipeline}-${prefix}@${projectid}.iam.gserviceaccount.com
+  ```
+
+1. Grant the new service account editor access to your project:
+
+  ```
+  gcloud projects add-iam-policy-binding ${projectid} \
+      --member serviceAccount:${pipeline}-${prefix}@${projectid}.iam.gserviceaccount.com \
+      --role roles/storage.admin
+  ```
+1. Provision required infrastructure with `terraform` and the `main.tf` manifest in this directory:
+
+  ```
+  terraform apply -var projectid=${projectid} -var pipeline=${pipeline}
+  ```
+
+1. If you want release blobs to be downloadable without authentication, go to the [Storage browser](https://console.cloud.google.com/storage/browser/) console, choose **Edit object default permissions** for the bucket created by Terraform, and add a `publicRead` entry for the `allUsers` user.
+
+1. Copy the credentials template file:
+
+  ```
+  cp credentials.yml.tpl credentials-${pipeline}.yml
+  ```
+
+1. Update your credentials file:
+
+  ```
+  sed -i "s/{{bucket_name}}/$(terraform state show google_storage_bucket.pipeline-artifacts | grep id | awk -F '= ' '{print $2}')/" credentials-${pipeline}.yml
+  sed -i "s/{{service_account}}/${pipeline}-${prefix}@${projectid}.iam.gserviceaccount.com/" credentials-${pipeline}.yml
+  sed -i "s|{{service_account_key_json}}|`cat /tmp/${pipeline}-${prefix}.key.json`|" credentials-${pipeline}.yml
+  ``` 
+
+1. Navigate to the [Storage section](https://console.cloud.google.com/storage/settings) of the Google Cloud console, choose the **Interoperability** section, and click **Create a new key**. You will need the **Access key** and **Secret** generated from this step.
+
+1. Edit `credentials-*.yml` and set the `bucket_access_key` and `bucket_secret_key` with the values you just created.
+
+1. Edit `credentials-*.yml` and replace ` {{service_account_key_json}}` with the contents of `cat /tmp/${pipeline}-${prefix}.key.json`
+
+# Deploy Pipeline
+
+1. Login to Concourse:
+
+  ```
+  fly --target lambr login \
+    --team-name gcp-tools-release \
+    --concourse-url https://your-concourse-name -k
+  ```
+
+1. Upload the pipeline:
+
+  ```
+fly -t google set-pipeline -p ${pipeline}-gcp-tools-release -c pipeline-${pipeline}.yml -l credentials-${pipeline}.yml
+  ```

--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -1,0 +1,14 @@
+---
+# Google Cloud Storage
+bucket_access_key: {{bucket_access_key}} # GCS interop access key
+bucket_secret_key: {{bucket_secret_key}} # GCS interop secret key
+bucket_name:       {{bucket_name}} # GCS bucket for semver storage
+
+# Google service account
+service_account: {{service_account}}
+service_account_key_json: |
+  {{service_account_key_json}}
+
+# GitHub
+github_deployment_key_bosh_google_cpi_release: | # GitHub deployment key for release artifacts
+github_pr_access_token: # An access token with repo:status access, used to test PRs

--- a/ci/main.tf
+++ b/ci/main.tf
@@ -1,0 +1,22 @@
+variable "projectid" {
+    type = "string"
+}
+
+variable "pipeline" {
+    type = "string"
+}
+
+variable "region" {
+    type    = "string"
+    default = "us-east1"
+}
+
+provider "google" {
+    project = "${var.projectid}"
+    region  = "${var.region}"
+}
+
+resource "google_storage_bucket" "pipeline-artifacts" {
+  name     = "${var.pipeline}-gcp-tools-release"
+  location = "US"
+}

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -1,0 +1,65 @@
+---
+groups:
+  - name: gcp-tools-release
+    jobs:
+      - build-candidate
+
+jobs:
+  - name: build-candidate
+    serial: true
+    plan:
+      - aggregate:
+        - {trigger: true,  get: gcp-tools-release,   resource: gcp-tools-release-in}
+        - {trigger: false, get: version-semver, params: {bump: patch}}
+
+      - put: version-semver
+        params: {file: version-semver/number}
+
+      - task: build-release
+        file: gcp-tools-release/ci/tasks/build-candidate.yml
+
+      - put: gcp-tools-release-artifacts
+        params: {file: candidate/*.tgz}
+
+      - put: gcp-tools-release-artifacts-sha1
+        params: {file: candidate/*.tgz.sha1}
+
+resources:
+  - name: gcp-tools-release-in
+    type: git
+    source:
+      uri: https://github.com/evandbrown/gcp-tools-release.git
+      branch: develop
+      ignore_paths:
+        - .final_builds/**/*.yml
+        - releases/**/*.yml
+
+  - name: gcp-tools-release-artifacts
+    type: gcs-resource
+    source:
+      json_key: {{service_account_key_json}}
+      bucket:   {{bucket_name}}
+      regexp:   gcp-tools-release([0-9]+\.[0-9]+\.[0-9]+)\.tgz
+
+  - name: gcp-tools-release-artifacts-sha1
+    type: gcs-resource
+    source:
+      json_key: {{service_account_key_json}}
+      bucket:   {{bucket_name}}
+      regexp:   gcp-tools-release([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha1
+
+  - name: version-semver
+    type: semver
+    source:
+      key:               current-version
+      bucket:            {{bucket_name}}
+      access_key_id:     {{bucket_access_key}}
+      secret_access_key: {{bucket_secret_key}}
+      region:            US
+      endpoint:          storage.googleapis.com
+
+resource_types:
+  - name: gcs-resource
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+source gcp-tools-release/ci/tasks/utils.sh
+source /etc/profile.d/chruby-with-ruby-2.1.2.sh
+
+cpi_release_name="bosh-gcp-tools"
+semver=`cat version-semver/number`
+
+pushd gcp-tools-release
+  echo "Using BOSH CLI version..."
+  bosh version
+
+  echo "Creating CPI BOSH Release..."
+  bosh create release --name ${cpi_release_name} --version ${semver} --with-tarball
+popd
+
+image_path=gcp-tools-release/dev_releases/${cpi_release_name}/${cpi_release_name}-${semver}.tgz
+echo -n $(sha1sum $image_path | awk '{print $1}') > $image_path.sha1
+
+mv ${image_path} candidate/
+mv ${image_path}.sha1 candidate/

--- a/ci/tasks/build-candidate.yml
+++ b/ci/tasks/build-candidate.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/gce-cpi-release
+    tag: v2
+inputs:
+  - name: gcp-tools-release
+  - name: version-semver
+outputs:
+  - name: candidate
+run:
+  path: gcp-tools-release/ci/tasks/build-candidate.sh

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+check_param() {
+  local name=$1
+  local value=$(eval echo '$'$name)
+  if [ "$value" == 'replace-me' ]; then
+    echo "environment variable $name must be set"
+    exit 1
+  fi
+}
+
+print_git_state() {
+  echo "--> last commit..."
+  TERM=xterm-256color git log -1
+  echo "---"
+  echo "--> local changes (e.g., from 'fly execute')..."
+  TERM=xterm-256color git status --verbose
+  echo "---"
+}
+
+declare -a on_exit_items
+on_exit_items=()
+
+function on_exit {
+  echo "Running ${#on_exit_items[@]} on_exit items..."
+  for i in "${on_exit_items[@]}"
+  do
+    for try in $(seq 0 9); do
+      sleep $try
+      echo "Running cleanup command $i (try: ${try})"
+        eval $i || continue
+      break
+    done
+  done
+}
+
+function add_on_exit {
+  local n=${#on_exit_items[@]}
+  on_exit_items=("${on_exit_items[@]}" "$*")
+  if [[ $n -eq 0 ]]; then
+    trap on_exit EXIT
+  fi
+}

--- a/config/final.yml
+++ b/config/final.yml
@@ -3,4 +3,4 @@ final_name: gcp-tools
 blobstore:
   provider: s3
   options:
-    bucket_name: gcp-tools-release
+    bucket_name: gcp-tools-boshrelease


### PR DESCRIPTION
This change adds a simple Concourse pipeline that creates a BOSH release and its SHA1 and uploads them both to Google Cloud Storage. The accompanying README documents setting up the required infrastructure with Terraform.