### PR TITLE
GCS can be used as a blobstore for uploading blobs

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -3,4 +3,6 @@ final_name: gcp-tools
 blobstore:
   provider: s3
   options:
-    bucket_name: gcp-tools-boshrelease
+    bucket_name: gcp-tools-release
+    host: storage.googleapis.com
+    use_ssl: true


### PR DESCRIPTION
`config/final.yml` should be structured as:

```
blobstore:
  provider: s3
  options:
    bucket_name: your-bucket-name
    host: storage.googleapis.com
    use_ssl: true
```