### PR TITLE
Enable StackDriver Agent deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ properties:
 
 ### Deploying StackDriver Monitoring
 
+Set the `stackdriver-agent-key` metadata field with your StackDriver Agent API
+key. This can be found in the [StackDriver Agent
+Settings](https://app.google.stackdriver.com/settings/accounts/agent/).
+
+```
+gcloud compute project-info add-metadata --metadata stackdriver-agent-key=YOUR_STACKDRIVER_API_KEY
+```
+
 Add the `gcp-tools` release to the `release` section of your existing deployment manifest:
 
 ```

--- a/jobs/stackdriver-agent/templates/stackdriver_collectd_ctl
+++ b/jobs/stackdriver-agent/templates/stackdriver_collectd_ctl
@@ -17,13 +17,13 @@ case $1 in
 
     mkdir -p ${RUN_DIR} ${LOG_DIR}
 
-    GCE_INSTANCE_ID=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/id 2>/dev/null`
+    GCE_INSTANCE_ID=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/id 2>/dev/null || true`
     if [ -z "$GCE_INSTANCE_ID" ]; then
       echo "Unable to discover GCE Instance ID" >&2
       return 1
     fi
 
-    STACKDRIVER_API_KEY=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/project/attributes/stackdriver-agent-key 2>/dev/null`
+    STACKDRIVER_API_KEY=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/project/attributes/stackdriver-agent-key 2>/dev/null || true`
     if test -z "$STACKDRIVER_API_KEY" ; then
       echo "Unable to discover StackDriver API KEY" >&2
       return 1

--- a/jobs/stackdriver-agent/templates/stackdriver_extractor_ctl
+++ b/jobs/stackdriver-agent/templates/stackdriver_extractor_ctl
@@ -17,13 +17,13 @@ case $1 in
 
     mkdir -p ${RUN_DIR} ${LOG_DIR}
 
-    GCE_INSTANCE_ID=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/id 2>/dev/null`
+    GCE_INSTANCE_ID=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/id 2>/dev/null || true`
     if [ -z "$GCE_INSTANCE_ID" ]; then
       echo "Unable to discover GCE Instance ID" >&2
       return 1
     fi
 
-    STACKDRIVER_API_KEY=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/project/attributes/stackdriver-agent-key 2>/dev/null`
+    STACKDRIVER_API_KEY=`curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/project/attributes/stackdriver-agent-key 2>/dev/null || true`
     if test -z "$STACKDRIVER_API_KEY" ; then
       echo "Unable to discover StackDriver API KEY" >&2
       return 1


### PR DESCRIPTION
- Added documentation on how to set the stackdriver-agent-key metadata field. This can't be autodetected like other various compute properties.
- Added '|| true' to the metadata queries in the stackdriver start scripts. Without this a failure to get the metadata is a silent failure in the script. 

[#131196105](https://www.pivotaltracker.com/story/show/131196105)