### PR TITLE
Post container metrics

### DIFF
--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -3,7 +3,21 @@ package nozzle
 import (
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/evandbrown/gcp-tools-release/src/stackdriver-nozzle/stackdriver"
+	"fmt"
+	"strings"
 )
+
+type PostContainerMetricError struct {
+	Errors map[string]error
+}
+
+func (e *PostContainerMetricError) Error() string {
+	errors := []string{}
+	for name, err := range(e.Errors) {
+		errors = append(errors, fmt.Sprintf("%v: %v", name, err.Error()))
+	}
+	return strings.Join(errors, "\n")
+}
 
 type Nozzle struct {
 	StackdriverClient stackdriver.Client
@@ -29,35 +43,49 @@ func (n *Nozzle) HandleEvent(eventsEnvelope *events.Envelope) error {
 	}
 }
 
-func (n *Nozzle) postContainerMetrics(envelope Envelope) error {
+func (n *Nozzle) postContainerMetrics(envelope Envelope) *PostContainerMetricError {
 	containerMetric := envelope.GetContainerMetric()
 
 	labels := envelope.Labels()
 	labels["applicationId"] = containerMetric.GetApplicationId()
 
+	errors := map[string]error{}
+
 	err := n.StackdriverClient.PostMetric("diskBytesQuota", float64(containerMetric.GetDiskBytesQuota()), labels)
 	if err != nil {
-		return err
+		errors["diskBytesQuota"] = err
 	}
+
 	err = n.StackdriverClient.PostMetric("instanceIndex", float64(containerMetric.GetInstanceIndex()), labels)
 	if err != nil {
-		return err
+		errors["instanceIndex"] = err
 	}
+
 	err = n.StackdriverClient.PostMetric("cpuPercentage", float64(containerMetric.GetCpuPercentage()), labels)
 	if err != nil {
-		return err
+		errors["cpuPercentage"] = err
 	}
+
 	err = n.StackdriverClient.PostMetric("diskBytes", float64(containerMetric.GetDiskBytes()), labels)
 	if err != nil {
-		return err
+		errors["diskBytes"] = err
 	}
+
 	err = n.StackdriverClient.PostMetric("memoryBytes", float64(containerMetric.GetMemoryBytes()), labels)
 	if err != nil {
-		return err
+		errors["memoryBytes"] = err
 	}
+
 	err = n.StackdriverClient.PostMetric("memoryBytesQuota", float64(containerMetric.GetMemoryBytesQuota()), labels)
 	if err != nil {
-		return err
+		errors["memoryBytesQuota"] = err
 	}
-	return nil
+
+	if len(errors) == 0 {
+		return nil
+	} else {
+		return &PostContainerMetricError{
+			Errors: errors,
+		}
+	}
 }

--- a/src/stackdriver-nozzle/nozzle/nozzle_test.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle_test.go
@@ -112,33 +112,29 @@ var _ = Describe("Nozzle", func() {
 				"applicationId": applicationId,
 			}
 			Expect(len(sdClient.postedMetrics)).To(Equal(6))
-			Expect(sdClient.postedMetrics).To(ContainElement(
+			Expect(sdClient.postedMetrics).To(ConsistOf(
 				PostedMetric{"diskBytesQuota", float64(1073741824), labels},
-			))
-			Expect(sdClient.postedMetrics).To(ContainElement(
 				PostedMetric{"instanceIndex", float64(0), labels},
-			))
-			Expect(sdClient.postedMetrics).To(ContainElement(
 				PostedMetric{"cpuPercentage", 0.061651273460637, labels},
-			))
-			Expect(sdClient.postedMetrics).To(ContainElement(
 				PostedMetric{"diskBytes", float64(164634624), labels},
-			))
-			Expect(sdClient.postedMetrics).To(ContainElement(
 				PostedMetric{"memoryBytes", float64(16601088), labels},
-			))
-			Expect(sdClient.postedMetrics).To(ContainElement(
 				PostedMetric{"memoryBytesQuota", float64(33554432), labels},
 			))
 		})
 
 		It("returns error if client errors out", func() {
 			sdClient.postMetricError = errors.New("fail")
+			metricType := events.Envelope_ContainerMetric
+			envelope = &events.Envelope{
+				EventType:   &metricType,
+				ValueMetric: nil,
+			}
 
 			err := subject.HandleEvent(envelope)
 
 			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(Equal("fail"))
+			Expect(err.Error()).To(ContainSubstring("diskBytesQuota: fail"))
+			Expect(err.Error()).To(ContainSubstring("memoryBytesQuota: fail"))
 		})
 	})
 })

--- a/src/stackdriver-nozzle/nozzle/nozzle_test.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle_test.go
@@ -12,13 +12,13 @@ import (
 var _ = Describe("Nozzle", func() {
 
 	var (
-		mockStackdriverClient *MockStackdriverClient
-		subject               nozzle.Nozzle
+		sdClient *MockStackdriverClient
+		subject  nozzle.Nozzle
 	)
 
 	BeforeEach(func() {
-		mockStackdriverClient = &MockStackdriverClient{}
-		subject = nozzle.Nozzle{StackdriverClient: mockStackdriverClient}
+		sdClient = &MockStackdriverClient{}
+		subject = nozzle.Nozzle{StackdriverClient: sdClient}
 	})
 
 	Context("logging", func() {
@@ -32,58 +32,28 @@ var _ = Describe("Nozzle", func() {
 		})
 
 		It("ships something to the stackdriver client", func() {
-			var postedEvent interface{}
-			mockStackdriverClient.PostLogFn = func(e interface{}, _ map[string]string) {
-				postedEvent = e
-			}
-
 			subject.HandleEvent(envelope)
 
-			Expect(postedEvent).To(Equal(nozzle.Envelope{envelope}))
+			postedLog := sdClient.postedLogs[0]
+			Expect(postedLog.payload).To(Equal(nozzle.Envelope{envelope}))
+			Expect(postedLog.labels).To(Equal(map[string]string{
+				"event_type": "HttpStartStop",
+			}))
 		})
 
 		It("ships multiple events", func() {
-			count := 0
-			mockStackdriverClient.PostLogFn = func(e interface{}, _ map[string]string) {
-				count += 1
-			}
-
 			for i := 0; i < 10; i++ {
 				subject.HandleEvent(envelope)
 			}
 
-			Expect(count).To(Equal(10))
-		})
-
-		It("creates labels from the event", func() {
-			var labels map[string]string
-			mockStackdriverClient.PostLogFn = func(e interface{}, sentLabels map[string]string) {
-				labels = sentLabels
-			}
-
-			subject.HandleEvent(envelope)
-
-			Expect(labels).To(Equal(map[string]string{
-				"event_type": "HttpStartStop",
-			}))
+			Expect(len(sdClient.postedLogs)).To(Equal(10))
 		})
 	})
 
 	Context("metrics", func() {
 		var envelope *events.Envelope
 
-		It("should post the metric", func() {
-			var name string
-			var value float64
-			var labels map[string]string
-
-			mockStackdriverClient.PostMetricFn = func(n string, v float64, l map[string]string) error {
-				name = n
-				value = v
-				labels = l
-				return nil
-			}
-
+		It("should post the value metric", func() {
 			metricName := "memoryStats.lastGCPauseTimeNS"
 			metricValue := float64(536182)
 			metricType := events.Envelope_ValueMetric
@@ -101,17 +71,16 @@ var _ = Describe("Nozzle", func() {
 			err := subject.HandleEvent(envelope)
 			Expect(err).To(BeNil())
 
-			Expect(name).To(Equal(metricName))
-			Expect(value).To(Equal(metricValue))
-			Expect(labels).To(Equal(map[string]string{
+			postedMetric := sdClient.postedMetrics[0]
+			Expect(postedMetric.name).To(Equal(metricName))
+			Expect(postedMetric.value).To(Equal(metricValue))
+			Expect(postedMetric.labels).To(Equal(map[string]string{
 				"event_type": "ValueMetric",
 			}))
 		})
 
 		It("returns error if client errors out", func() {
-			mockStackdriverClient.PostMetricFn = func(string, float64, map[string]string) error {
-				return errors.New("fail")
-			}
+			sdClient.postMetricError = errors.New("fail")
 
 			err := subject.HandleEvent(envelope)
 
@@ -122,19 +91,29 @@ var _ = Describe("Nozzle", func() {
 })
 
 type MockStackdriverClient struct {
-	PostLogFn    func(interface{}, map[string]string)
-	PostMetricFn func(string, float64, map[string]string) error
+	postedLogs    []PostedLog
+	postedMetrics []PostedMetric
+
+	postMetricError error
 }
 
 func (m *MockStackdriverClient) PostLog(payload interface{}, labels map[string]string) {
-	if m.PostLogFn != nil {
-		m.PostLogFn(payload, labels)
-	}
+	m.postedLogs = append(m.postedLogs, PostedLog{payload, labels})
 }
 
 func (m *MockStackdriverClient) PostMetric(name string, value float64, labels map[string]string) error {
-	if m.PostMetricFn != nil {
-		return m.PostMetricFn(name, value, labels)
-	}
-	return nil
+	m.postedMetrics = append(m.postedMetrics, PostedMetric{name, value, labels})
+
+	return m.postMetricError
+}
+
+type PostedLog struct {
+	payload interface{}
+	labels  map[string]string
+}
+
+type PostedMetric struct {
+	name   string
+	value  float64
+	labels map[string]string
 }


### PR DESCRIPTION
Post container metrics as metrics instead of logs. We would like some feedback on how we handle the async error channel for the container metrics. 